### PR TITLE
DRL improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all fmt test tidy
+.PHONY: all fmt test stresstest tidy
 
 all: fmt test tidy
 
@@ -7,6 +7,9 @@ fmt:
 
 test:
 	go test -race -v -count=1 -cover .
+
+stresstest:
+	go test -race -failfast -count=1000 -cover .
 
 tidy:
 	go mod tidy

--- a/drl.go
+++ b/drl.go
@@ -35,7 +35,8 @@ func (d *DRL) Ready() bool {
 }
 
 func (d *DRL) IsOpen() bool {
-	return d.open.Load().(bool)
+	value, ok := d.open.Load().(bool)
+	return value && ok
 }
 
 func (d *DRL) SetCurrentTokenValue(newValue int64) {

--- a/drl.go
+++ b/drl.go
@@ -35,8 +35,8 @@ func (d *DRL) Ready() bool {
 }
 
 func (d *DRL) IsOpen() bool {
-	value, ok := d.open.Load().(bool)
-	return value && ok
+	open, _ := d.open.Load().(bool)
+	return open
 }
 
 func (d *DRL) SetCurrentTokenValue(newValue int64) {

--- a/drl.go
+++ b/drl.go
@@ -27,7 +27,6 @@ type DRL struct {
 	currentTokenValue int64
 	open              atomic.Value
 	stopC             chan struct{}
-	once              sync.Once
 }
 
 func (d *DRL) Ready() bool {
@@ -81,11 +80,11 @@ func (d *DRL) uniqueID(s Server) string {
 }
 
 func (d *DRL) Close() {
-	d.once.Do(func() {
-		d.open.Store(false)
+	wasOpen, _ := d.open.Swap(false).(bool)
+	if wasOpen {
 		close(d.stopC)
 		d.Servers.Close()
-	})
+	}
 }
 
 func (d *DRL) totalLoadAcrossServers() int64 {

--- a/drl.go
+++ b/drl.go
@@ -64,7 +64,7 @@ func (d *DRL) startLoop(ctx context.Context) {
 		case <-ctx.Done():
 			d.Close()
 			return
-		case _, _ = <-d.stopC:
+		case <-d.stopC:
 			return
 		case <-t.C:
 			d.mutex.Lock()

--- a/drl_test.go
+++ b/drl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -30,6 +31,18 @@ func TestDRLInit(t *testing.T) {
 		err := addOrUpdateServer(ratelimiter, server)
 		assert.NoError(t, err)
 	})
+}
+
+func TestDRLCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	ratelimiter := setupDRL(ctx)
+	defer ratelimiter.Close()
+
+	<-ctx.Done()
 }
 
 func setupDRL(ctx context.Context) *drl.DRL {

--- a/drl_test.go
+++ b/drl_test.go
@@ -45,6 +45,13 @@ func TestDRLCancellation(t *testing.T) {
 	<-ctx.Done()
 }
 
+func TestDRLCloser(t *testing.T) {
+	t.Parallel()
+
+	ratelimiter := setupDRL(context.Background())
+	ratelimiter.Close()
+}
+
 func setupDRL(ctx context.Context) *drl.DRL {
 	result := &drl.DRL{}
 	result.Init(ctx)

--- a/item.go
+++ b/item.go
@@ -7,26 +7,26 @@ import (
 
 // Item represents a record in the cache map
 type Item struct {
-	sync.RWMutex
+	mu      sync.RWMutex
 	data    Server
 	expires *time.Time
 }
 
 func (item *Item) touch(duration time.Duration) {
-	item.Lock()
+	item.mu.Lock()
 	expiration := time.Now().Add(duration)
 	item.expires = &expiration
-	item.Unlock()
+	item.mu.Unlock()
 }
 
 func (item *Item) expired() bool {
 	var value bool
-	item.RLock()
+	item.mu.RLock()
 	if item.expires == nil {
 		value = true
 	} else {
 		value = item.expires.Before(time.Now())
 	}
-	item.RUnlock()
+	item.mu.RUnlock()
 	return value
 }

--- a/ttlcache.go
+++ b/ttlcache.go
@@ -76,8 +76,8 @@ func (c *Cache) Count() int {
 
 // Close frees up resources used by the cache.
 func (c *Cache) Close() {
-	wasOpen := c.open.Swap(false)
-	if wasOpen.(bool) {
+	wasOpen, _ := c.open.Swap(false).(bool)
+	if wasOpen {
 		c.stopC <- struct{}{}
 		c.items = nil
 		close(c.stopC)

--- a/ttlcache.go
+++ b/ttlcache.go
@@ -76,7 +76,8 @@ func (c *Cache) Count() int {
 
 // Close frees up resources used by the cache.
 func (c *Cache) Close() {
-	if c.IsOpen() {
+	wasOpen := c.open.Swap(false)
+	if wasOpen.(bool) {
 		c.stopC <- struct{}{}
 		c.items = nil
 		close(c.stopC)
@@ -103,7 +104,6 @@ func (c *Cache) startCleanupTimer() {
 	for {
 		select {
 		case <-c.stopC:
-			c.open.Store(false)
 			return
 		case <-t.C:
 			c.cleanup()

--- a/ttlcache.go
+++ b/ttlcache.go
@@ -94,10 +94,12 @@ func (c *Cache) cleanup() {
 	c.mutex.Unlock()
 }
 
+var minimumCleanupInterval = time.Second
+
 func (c *Cache) startCleanupTimer() {
 	duration := c.ttl
-	if duration < time.Second {
-		duration = time.Second
+	if duration < minimumCleanupInterval {
+		duration = minimumCleanupInterval
 	}
 	t := time.NewTicker(duration)
 	defer t.Stop()

--- a/ttlcache_test.go
+++ b/ttlcache_test.go
@@ -34,7 +34,7 @@ func TestCache(t *testing.T) {
 		assert.False(t, c.IsOpen(), "expected the cache to be closed")
 	})
 
-	t.Run("Set, Get", func(t *testing.T) {
+	t.Run("Set, Get valid", func(t *testing.T) {
 		t.Parallel()
 
 		c := NewCache(10 * time.Millisecond)
@@ -46,7 +46,7 @@ func TestCache(t *testing.T) {
 		assert.True(t, ok, "expected valid key")
 	})
 
-	t.Run("Set, Get", func(t *testing.T) {
+	t.Run("Set, Get expired", func(t *testing.T) {
 		t.Parallel()
 
 		c := NewCache(0)

--- a/ttlcache_test.go
+++ b/ttlcache_test.go
@@ -4,35 +4,76 @@ import (
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCache(t *testing.T) {
-	t.Run("IsOpen", func(ts *testing.T) {
+	t.Parallel()
+
+	t.Run("IsOpen", func(t *testing.T) {
+		t.Parallel()
+
 		c := NewCache(0)
-		if !c.IsOpen() {
-			t.Error("expected the cache to be open")
-		}
-		c.Close()
-	})
-	t.Run("Close", func(ts *testing.T) {
-		c := NewCache(0)
-		c.Close()
-		if c.IsOpen() {
-			t.Error("expected the cache to be closed")
-		}
-	})
-	t.Run("Item evictions", func(ts *testing.T) {
-		// This test ensures that we are correctly evicting expired items. We set ttl
-		// to me 1ms, this will force the eviction loop to use 1s interval for
-		// eviction.
-		c := NewCache(time.Millisecond)
 		defer c.Close()
 
-		// Ticking at 100ms we will reach 1s after 10 ticks, meaning any items added
-		// after 10th tick will be available in the cache because tey will be evicted
-		// on 20th tick.
+		assert.True(t, c.IsOpen(), "expected the cache to be open")
+	})
+
+	t.Run("Close", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCache(0)
+		c.Close()
+
+		assert.False(t, c.IsOpen(), "expected the cache to be closed")
+	})
+
+	t.Run("Set, Get", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCache(10 * time.Millisecond)
+		defer c.Close()
+
+		key := "key"
+		c.Set(key, Server{})
+		_, ok := c.Get(key)
+		assert.True(t, ok, "expected valid key")
+	})
+
+	t.Run("Set, Get", func(t *testing.T) {
+		t.Parallel()
+
+		c := NewCache(0)
+		defer c.Close()
+
+		key := "key"
+		c.Set(key, Server{})
+		_, ok := c.Get(key)
+		assert.False(t, ok, "expected key to be expired")
+	})
+
+	t.Run("Item evictions", func(t *testing.T) {
+		t.Parallel()
+
+		// This test ensures that we are correctly evicting expired items. We set ttl
+		// to me 5ms, this will force the eviction loop to use 1s interval for
+		// eviction.
+
+		c := NewCache(5 * time.Millisecond)
+		defer c.Close()
+
+		// Offset adding items by 50ms, so we can more reliably predict how many
+		// items will be left in the cache at expiry.
+
+		time.Sleep(50 * time.Millisecond)
+
+		// Start a ticker so we may add a new cache item every 100ms.
+		// Add 14 items, 5 of which will be added in the next expiry interval.
+
 		tick := time.NewTicker(100 * time.Millisecond)
 		defer tick.Stop()
+
 		var n int64
 		for range tick.C {
 			n++
@@ -41,20 +82,12 @@ func TestCache(t *testing.T) {
 			}
 			c.Set(strconv.FormatInt(n, 10), Server{})
 		}
-		count := c.Count()
-		if count != 5 {
-			ts.Errorf("expected 5 items to remain in the cache got %d instead", count)
-		}
-		_, ok := c.Get("14")
-		if ok {
-			t.Error("expected the key to have expired")
-		}
-		key := "key"
-		c.Set(key, Server{})
-		_, ok = c.Get(key)
-		if !ok {
-			t.Error("expected the key to exist")
-		}
+
+		// Assert the expected cache item count.
+
+		got := c.Count()
+		want := 5
+		assert.Equal(t, want, got, "expected %d items to remain in the cache got %d instead", want, got)
 	})
 }
 


### PR DESCRIPTION
This PR fixes a number of issues:

- DRL.Init didn't allocate the stop channel,
- DRL didn't really work with Close or with context cancellation, adds tests for that,
- Cache had a race condition in Close() which added up to a flaky test,
- Adjust the minimum expiry interval for tests.

How this was tested:

```
go test -race -failfast -count=1000 -cover .
ok  	github.com/TykTechnologies/drl	158.903s	coverage: 90.7% of statements
```

The code coverage increased by about +12% (78.X% to 90.7%)on account of actually hitting the problematic code branches.