### PR TITLE
[TT-10829] Fix initial DRL warmup by setting current token value cost

### DIFF
--- a/drl.go
+++ b/drl.go
@@ -48,6 +48,7 @@ func (d *DRL) CurrentTokenValue() int64 {
 func (d *DRL) Init(ctx context.Context) {
 	d.Servers = NewCache(4 * time.Second)
 	d.RequestTokenValue = 100
+	d.currentTokenValue = 100
 	d.serverIndex = make(map[string]Server)
 	d.stopC = make(chan struct{})
 


### PR DESCRIPTION
The `currentTokenValue` was uninitialized. This leads to unwanted behaviour before the first server is registered in `AddOrUpdateServer`. Until that function is ran, the request cost would be 0, which is invalid.

Before:
![image](https://github.com/TykTechnologies/drl/assets/233360/e2d8927b-aa14-437f-a45d-dc27a9fba105)

After:
![image](https://github.com/TykTechnologies/drl/assets/233360/1bfb9edd-e982-4fee-b9cd-6dee3572e962)

https://tyktech.atlassian.net/browse/TT-10829